### PR TITLE
新增 8 个主题并补充中文逐行注释

### DIFF
--- a/theme/BlackGold.conf
+++ b/theme/BlackGold.conf
@@ -1,0 +1,133 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 白底黑金
+PanelColor=#ffffff
+# 淡金高亮
+HighlightColor=#faf7f0
+# 高亮悬停色
+HighlightHoverColor=#f5f0e1
+# 高亮字：黑
+HighlightTextColor=#000000
+# 标签/标记：香槟金
+HighlightLabelColor=#d4af37
+HighlightCommentColor=#bfa030
+HighlightMarkColor=#d4af37
+
+# 主文字颜色
+TextColor=#2b2b2b
+# 标签颜色
+LabelColor=#888888
+# 注释颜色
+CommentColor=#aaaaaa
+# 翻页按钮
+PagingButtonColor=#888888
+# 禁用翻页按钮
+DisabledPagingButtonColor=#e0e0e0
+# 辅助指示色
+AuxColor=#2b2b2b
+
+# 预编辑：光标前
+PreeditColorPreCaret=#d4af37
+# 预编辑：光标
+PreeditColorCaret=#000000
+# 预编辑：光标后
+PreeditColorPostCaret=#2b2b2b
+
+# 边框色
+BorderColor=#ebebeb
+# 分隔线
+DividerColor=#faf7f0
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+# 黑金深色
+PanelColor=#121212
+# 深灰高亮
+HighlightColor=#262626
+# 高亮悬停
+HighlightHoverColor=#333333
+# 高亮字：金
+HighlightTextColor=#d4af37
+HighlightTextPressColor=#f7e7ce
+# 标签：暗金
+HighlightLabelColor=#c5a059
+HighlightCommentColor=#8c7335
+HighlightMarkColor=#d4af37
+
+# 文字：银灰
+TextColor=#e0e0e0
+LabelColor=#555555
+CommentColor=#444444
+PagingButtonColor=#d4af37
+DisabledPagingButtonColor=#333333
+AuxColor=#e0e0e0
+
+# 预编辑：光标前
+PreeditColorPreCaret=#d4af37
+# 预编辑：光标
+PreeditColorCaret=#f7e7ce
+# 预编辑：光标后
+PreeditColorPostCaret=#e0e0e0
+
+# 边框色
+BorderColor=#333333
+# 分隔线
+DividerColor=#262626
+
+[Typography]
+# 布局方向
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=None
+
+[Background]
+# 模糊开启
+Blur=True
+# 模糊半径
+BlurRadius=8
+# 阴影
+Shadow=True
+
+[Font]
+# 主文字字号
+TextFontSize=17
+# 标签字号
+LabelFontSize=14
+# 注释字号
+CommentFontSize=12
+# 预编辑字号
+PreeditFontSize=17
+
+[Size]
+# 是否覆盖默认尺寸
+OverrideDefault=True
+# 边框宽度
+BorderWidth=1
+# 直角/极小圆角
+BorderRadius=4
+# 外边距
+Margin=4
+# 高亮圆角
+HighlightRadius=2
+# 上内边距
+TopPadding=8
+# 右内边距
+RightPadding=12
+# 下内边距
+BottomPadding=8
+# 左内边距
+LeftPadding=12
+# 标签与文字间距
+LabelTextGap=10
+# 最小宽度（垂直）
+VerticalMinWidth=180
+# 滚动单元宽度
+ScrollCellWidth=65
+# 水平分隔线宽度
+HorizontalDividerWidth=0

--- a/theme/BlackGold.conf
+++ b/theme/BlackGold.conf
@@ -1,133 +1,178 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 白底黑金
-PanelColor=#ffffff
-# 淡金高亮
+# 高亮颜色
 HighlightColor=#faf7f0
-# 高亮悬停色
+# 悬停时高亮颜色
 HighlightHoverColor=#f5f0e1
-# 高亮字：黑
+# 高亮文本颜色
 HighlightTextColor=#000000
-# 标签/标记：香槟金
+# 按下时高亮文本颜色
+HighlightTextPressColor=#7f7f7f
+# 高亮标签颜色
 HighlightLabelColor=#d4af37
+# 高亮注释颜色
 HighlightCommentColor=#bfa030
+# 高亮标记颜色
 HighlightMarkColor=#d4af37
-
-# 主文字颜色
+# 面板颜色
+PanelColor=#ffffff
+# 文本颜色
 TextColor=#2b2b2b
 # 标签颜色
 LabelColor=#888888
 # 注释颜色
 CommentColor=#aaaaaa
-# 翻页按钮
+# 翻页按钮颜色
 PagingButtonColor=#888888
-# 禁用翻页按钮
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#e0e0e0
-# 辅助指示色
+# 指示文本颜色
 AuxColor=#2b2b2b
-
-# 预编辑：光标前
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#d4af37
-# 预编辑：光标
+# 预编辑光标颜色
 PreeditColorCaret=#000000
-# 预编辑：光标后
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#2b2b2b
-
-# 边框色
+# 边框颜色
 BorderColor=#ebebeb
-# 分隔线
+# 分隔线颜色
 DividerColor=#faf7f0
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
-# 黑金深色
-PanelColor=#121212
-# 深灰高亮
+# 高亮颜色
 HighlightColor=#262626
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#333333
-# 高亮字：金
+# 高亮文本颜色
 HighlightTextColor=#d4af37
+# 按下时高亮文本颜色
 HighlightTextPressColor=#f7e7ce
-# 标签：暗金
+# 高亮标签颜色
 HighlightLabelColor=#c5a059
+# 高亮注释颜色
 HighlightCommentColor=#8c7335
+# 高亮标记颜色
 HighlightMarkColor=#d4af37
-
-# 文字：银灰
+# 面板颜色
+PanelColor=#121212
+# 文本颜色
 TextColor=#e0e0e0
+# 标签颜色
 LabelColor=#555555
+# 注释颜色
 CommentColor=#444444
+# 翻页按钮颜色
 PagingButtonColor=#d4af37
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#333333
+# 指示文本颜色
 AuxColor=#e0e0e0
-
-# 预编辑：光标前
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#d4af37
-# 预编辑：光标
+# 预编辑光标颜色
 PreeditColorCaret=#f7e7ce
-# 预编辑：光标后
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#e0e0e0
-
-# 边框色
+# 边框颜色
 BorderColor=#333333
-# 分隔线
+# 分隔线颜色
 DividerColor=#262626
 
 [Typography]
-# 布局方向
+# 布局
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=None
 
 [Background]
-# 模糊开启
-Blur=True
-# 模糊半径
-BlurRadius=8
+# 图片
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=System
 # 阴影
 Shadow=True
 
 [Font]
-# 主文字字号
+# 文本字号
 TextFontSize=17
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=14
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=12
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=17
+# 预编辑字重
+PreeditFontWeight=400
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本
+Text=‸
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=🐧
+# 悬停行为
+HoverBehavior=None
 
 [Size]
-# 是否覆盖默认尺寸
+# 覆盖默认值
 OverrideDefault=True
-# 边框宽度
+# 边框宽度（px）
 BorderWidth=1
-# 直角/极小圆角
+# 边框半径（px）
 BorderRadius=4
-# 外边距
+# 外边距（px）
 Margin=4
-# 高亮圆角
+# 高亮半径（px）
 HighlightRadius=2
-# 上内边距
+# 顶填充（px）
 TopPadding=8
-# 右内边距
+# 右填充（px）
 RightPadding=12
-# 下内边距
+# 底填充（px）
 BottomPadding=8
-# 左内边距
+# 左填充（px）
 LeftPadding=12
-# 标签与文字间距
+# 标签、文本、注释间隔（px）
 LabelTextGap=10
-# 最小宽度（垂直）
+# 垂直时最小宽度（px）
 VerticalMinWidth=180
-# 滚动单元宽度
+# 卷轴单元格宽度 (px)
 ScrollCellWidth=65
-# 水平分隔线宽度
+# 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/Ink.conf
+++ b/theme/Ink.conf
@@ -1,0 +1,111 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 宣纸白底
+PanelColor=#fbf9f4
+# 淡墨高亮
+HighlightColor=#ebe8e3
+# 高亮悬停
+HighlightHoverColor=#e0ddd8
+# 浓墨高亮字
+HighlightTextColor=#000000
+HighlightTextPressColor=#000000
+# 朱砂标签/标记
+HighlightLabelColor=#c0392b
+HighlightCommentColor=#555555
+HighlightMarkColor=#c0392b
+
+# 文字：炭灰
+TextColor=#2b2b2b
+LabelColor=#999999
+CommentColor=#999999
+PagingButtonColor=#555555
+DisabledPagingButtonColor=#dcdcdc
+AuxColor=#2b2b2b
+
+# 预编辑：朱砂光标
+PreeditColorPreCaret=#c0392b
+PreeditColorCaret=#c0392b
+PreeditColorPostCaret=#2b2b2b
+
+# 边框色
+BorderColor=#e8e6e1
+# 分隔线
+DividerColor=#ebe8e3
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+# 黑纸金字
+PanelColor=#1a1a1a
+HighlightColor=#333333
+HighlightTextColor=#d4af37
+TextColor=#cccccc
+LabelColor=#666666
+CommentColor=#666666
+PagingButtonColor=#d4af37
+DisabledPagingButtonColor=#444444
+AuxColor=#d4af37
+PreeditColorPreCaret=#d4af37
+PreeditColorCaret=#c0392b
+PreeditColorPostCaret=#cccccc
+# 边框色
+BorderColor=#00000000
+# 分隔线
+DividerColor=#333333
+
+[Typography]
+# 布局
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=Arrow
+
+[Background]
+# 模糊开关
+Blur=True
+# 模糊半径
+BlurRadius=8
+# 阴影
+Shadow=True
+
+[Font]
+# 主文字字号
+TextFontSize=17
+# 标签字号
+LabelFontSize=14
+# 注释字号
+CommentFontSize=12
+# 预编辑字号
+PreeditFontSize=17
+
+[Size]
+# 是否覆盖默认尺寸
+OverrideDefault=True
+# 边框宽度
+BorderWidth=0
+# 圆角
+BorderRadius=8
+# 外边距
+Margin=6
+# 高亮圆角
+HighlightRadius=4
+# 上内边距
+TopPadding=8
+# 右内边距
+RightPadding=12
+# 下内边距
+BottomPadding=8
+# 左内边距
+LeftPadding=12
+# 标签间距
+LabelTextGap=10
+# 垂直最小宽度
+VerticalMinWidth=160
+# 滚动单元宽度
+ScrollCellWidth=65
+# 水平分隔线宽度
+HorizontalDividerWidth=0

--- a/theme/Ink.conf
+++ b/theme/Ink.conf
@@ -1,59 +1,87 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 宣纸白底
-PanelColor=#fbf9f4
-# 淡墨高亮
+# 高亮颜色
 HighlightColor=#ebe8e3
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#e0ddd8
-# 浓墨高亮字
+# 高亮文本颜色
 HighlightTextColor=#000000
+# 按下时高亮文本颜色
 HighlightTextPressColor=#000000
-# 朱砂标签/标记
+# 高亮标签颜色
 HighlightLabelColor=#c0392b
+# 高亮注释颜色
 HighlightCommentColor=#555555
+# 高亮标记颜色
 HighlightMarkColor=#c0392b
-
-# 文字：炭灰
+# 面板颜色
+PanelColor=#fbf9f4
+# 文本颜色
 TextColor=#2b2b2b
+# 标签颜色
 LabelColor=#999999
+# 注释颜色
 CommentColor=#999999
+# 翻页按钮颜色
 PagingButtonColor=#555555
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#dcdcdc
+# 指示文本颜色
 AuxColor=#2b2b2b
-
-# 预编辑：朱砂光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#c0392b
+# 预编辑光标颜色
 PreeditColorCaret=#c0392b
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#2b2b2b
-
-# 边框色
+# 边框颜色
 BorderColor=#e8e6e1
-# 分隔线
+# 分隔线颜色
 DividerColor=#ebe8e3
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
-# 黑纸金字
-PanelColor=#1a1a1a
+# 高亮颜色
 HighlightColor=#333333
+# 悬停时高亮颜色
+HighlightHoverColor=#454545
+# 高亮文本颜色
 HighlightTextColor=#d4af37
+# 按下时高亮文本颜色
+HighlightTextPressColor=#ff7eb6
+# 高亮标签颜色
+HighlightLabelColor=#ff7eb6
+# 高亮注释颜色
+HighlightCommentColor=#ff7eb6
+# 高亮标记颜色
+HighlightMarkColor=#ff7eb6
+# 面板颜色
+PanelColor=#1a1a1a
+# 文本颜色
 TextColor=#cccccc
+# 标签颜色
 LabelColor=#666666
+# 注释颜色
 CommentColor=#666666
+# 翻页按钮颜色
 PagingButtonColor=#d4af37
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#444444
+# 指示文本颜色
 AuxColor=#d4af37
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#d4af37
+# 预编辑光标颜色
 PreeditColorCaret=#c0392b
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#cccccc
-# 边框色
+# 边框颜色
 BorderColor=#00000000
-# 分隔线
+# 分隔线颜色
 DividerColor=#333333
 
 [Typography]
@@ -61,51 +89,90 @@ DividerColor=#333333
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=Arrow
 
 [Background]
-# 模糊开关
-Blur=True
-# 模糊半径
-BlurRadius=8
+# 图片
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=System
 # 阴影
 Shadow=True
 
 [Font]
-# 主文字字号
+# 文本字号
 TextFontSize=17
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=14
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=12
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=17
+# 预编辑字重
+PreeditFontWeight=400
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本
+Text=|
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=
+# 悬停行为
+HoverBehavior=Move
 
 [Size]
-# 是否覆盖默认尺寸
+# 覆盖默认值
 OverrideDefault=True
-# 边框宽度
+# 边框宽度（px）
 BorderWidth=0
-# 圆角
+# 边框半径（px）
 BorderRadius=8
-# 外边距
+# 外边距（px）
 Margin=6
-# 高亮圆角
+# 高亮半径（px）
 HighlightRadius=4
-# 上内边距
+# 顶填充（px）
 TopPadding=8
-# 右内边距
+# 右填充（px）
 RightPadding=12
-# 下内边距
+# 底填充（px）
 BottomPadding=8
-# 左内边距
+# 左填充（px）
 LeftPadding=12
-# 标签间距
+# 标签、文本、注释间隔（px）
 LabelTextGap=10
-# 垂直最小宽度
+# 垂直时最小宽度（px）
 VerticalMinWidth=160
-# 滚动单元宽度
+# 卷轴单元格宽度 (px)
 ScrollCellWidth=65
-# 水平分隔线宽度
+# 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/Matcha.conf
+++ b/theme/Matcha.conf
@@ -1,0 +1,110 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 淡抹茶底
+PanelColor=#f2f7f2
+# 薄荷绿高亮
+HighlightColor=#e0ebe0
+# 高亮悬停
+HighlightHoverColor=#d6e6d6
+# 深绿高亮字
+HighlightTextColor=#2d5a3f
+HighlightTextPressColor=#1e3d2b
+HighlightLabelColor=#2d5a3f
+HighlightCommentColor=#5c8a6f
+HighlightMarkColor=#2d5a3f
+
+# 文字：深灰绿
+TextColor=#2c332e
+LabelColor=#8ba391
+CommentColor=#8ba391
+PagingButtonColor=#8ba391
+DisabledPagingButtonColor=#ccd6d0
+AuxColor=#5c8a6f
+
+# 预编辑：深绿+亮绿光标
+PreeditColorPreCaret=#2d5a3f
+PreeditColorCaret=#4caf50
+PreeditColorPostCaret=#2c332e
+
+# 边框色
+BorderColor=#ffffff
+# 分隔线
+DividerColor=#e0ebe0
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+# 深夜森林
+PanelColor=#1b261f
+HighlightColor=#2a3d31
+HighlightTextColor=#a3cfb4
+TextColor=#e0ebe0
+LabelColor=#5c7a65
+CommentColor=#5c7a65
+PagingButtonColor=#a3cfb4
+DisabledPagingButtonColor=#2a3d31
+AuxColor=#a3cfb4
+PreeditColorPreCaret=#a3cfb4
+PreeditColorCaret=#4caf50
+PreeditColorPostCaret=#e0ebe0
+# 边框色
+BorderColor=#00000000
+# 分隔线
+DividerColor=#2a3d31
+
+[Typography]
+# 布局
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=Triangle
+
+[Background]
+# 模糊开关
+Blur=True
+# 模糊半径
+BlurRadius=12
+# 阴影
+Shadow=True
+
+[Font]
+# 主文字字号
+TextFontSize=16
+# 标签字号
+LabelFontSize=14
+# 注释字号
+CommentFontSize=12
+# 预编辑字号
+PreeditFontSize=16
+
+[Size]
+# 是否覆盖默认尺寸
+OverrideDefault=True
+# 边框宽度
+BorderWidth=1
+# 圆角
+BorderRadius=10
+# 外边距
+Margin=6
+# 高亮圆角
+HighlightRadius=8
+# 上内边距
+TopPadding=6
+# 右内边距
+RightPadding=12
+# 下内边距
+BottomPadding=6
+# 左内边距
+LeftPadding=12
+# 标签间距
+LabelTextGap=8
+# 垂直最小宽度
+VerticalMinWidth=160
+# 滚动单元宽度
+ScrollCellWidth=65
+# 水平分隔线宽度
+HorizontalDividerWidth=0

--- a/theme/Matcha.conf
+++ b/theme/Matcha.conf
@@ -1,58 +1,87 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 淡抹茶底
-PanelColor=#f2f7f2
-# 薄荷绿高亮
+# 高亮颜色
 HighlightColor=#e0ebe0
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#d6e6d6
-# 深绿高亮字
+# 高亮文本颜色
 HighlightTextColor=#2d5a3f
+# 按下时高亮文本颜色
 HighlightTextPressColor=#1e3d2b
+# 高亮标签颜色
 HighlightLabelColor=#2d5a3f
+# 高亮注释颜色
 HighlightCommentColor=#5c8a6f
+# 高亮标记颜色
 HighlightMarkColor=#2d5a3f
-
-# 文字：深灰绿
+# 面板颜色
+PanelColor=#f2f7f2
+# 文本颜色
 TextColor=#2c332e
+# 标签颜色
 LabelColor=#8ba391
+# 注释颜色
 CommentColor=#8ba391
+# 翻页按钮颜色
 PagingButtonColor=#8ba391
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#ccd6d0
+# 指示文本颜色
 AuxColor=#5c8a6f
-
-# 预编辑：深绿+亮绿光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#2d5a3f
+# 预编辑光标颜色
 PreeditColorCaret=#4caf50
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#2c332e
-
-# 边框色
+# 边框颜色
 BorderColor=#ffffff
-# 分隔线
+# 分隔线颜色
 DividerColor=#e0ebe0
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
-# 深夜森林
-PanelColor=#1b261f
+# 高亮颜色
 HighlightColor=#2a3d31
+# 悬停时高亮颜色
+HighlightHoverColor=#454545
+# 高亮文本颜色
 HighlightTextColor=#a3cfb4
+# 按下时高亮文本颜色
+HighlightTextPressColor=#ff7eb6
+# 高亮标签颜色
+HighlightLabelColor=#ff7eb6
+# 高亮注释颜色
+HighlightCommentColor=#ff7eb6
+# 高亮标记颜色
+HighlightMarkColor=#ff7eb6
+# 面板颜色
+PanelColor=#1b261f
+# 文本颜色
 TextColor=#e0ebe0
+# 标签颜色
 LabelColor=#5c7a65
+# 注释颜色
 CommentColor=#5c7a65
+# 翻页按钮颜色
 PagingButtonColor=#a3cfb4
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#2a3d31
+# 指示文本颜色
 AuxColor=#a3cfb4
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#a3cfb4
+# 预编辑光标颜色
 PreeditColorCaret=#4caf50
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#e0ebe0
-# 边框色
+# 边框颜色
 BorderColor=#00000000
-# 分隔线
+# 分隔线颜色
 DividerColor=#2a3d31
 
 [Typography]
@@ -60,51 +89,90 @@ DividerColor=#2a3d31
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=Triangle
 
 [Background]
-# 模糊开关
-Blur=True
-# 模糊半径
-BlurRadius=12
+# 图片
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=System
 # 阴影
 Shadow=True
 
 [Font]
-# 主文字字号
+# 文本字号
 TextFontSize=16
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=14
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=12
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=16
+# 预编辑字重
+PreeditFontWeight=400
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本
+Text=|
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=
+# 悬停行为
+HoverBehavior=Move
 
 [Size]
-# 是否覆盖默认尺寸
+# 覆盖默认值
 OverrideDefault=True
-# 边框宽度
+# 边框宽度（px）
 BorderWidth=1
-# 圆角
+# 边框半径（px）
 BorderRadius=10
-# 外边距
+# 外边距（px）
 Margin=6
-# 高亮圆角
+# 高亮半径（px）
 HighlightRadius=8
-# 上内边距
+# 顶填充（px）
 TopPadding=6
-# 右内边距
+# 右填充（px）
 RightPadding=12
-# 下内边距
+# 底填充（px）
 BottomPadding=6
-# 左内边距
+# 左填充（px）
 LeftPadding=12
-# 标签间距
+# 标签、文本、注释间隔（px）
 LabelTextGap=8
-# 垂直最小宽度
+# 垂直时最小宽度（px）
 VerticalMinWidth=160
-# 滚动单元宽度
+# 卷轴单元格宽度 (px)
 ScrollCellWidth=65
-# 水平分隔线宽度
+# 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/Morandi.conf
+++ b/theme/Morandi.conf
@@ -1,0 +1,110 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 纯白面板
+PanelColor=#ffffff
+# 雾霾紫高亮
+HighlightColor=#f3f0f7
+# 高亮悬停
+HighlightHoverColor=#ede8f2
+# 深紫高亮字
+HighlightTextColor=#6a5acd
+HighlightTextPressColor=#483d8b
+HighlightLabelColor=#6a5acd
+HighlightCommentColor=#9370db
+HighlightMarkColor=#6a5acd
+
+# 文字：深岩灰
+TextColor=#333344
+LabelColor=#a0a0b0
+CommentColor=#b0b0c0
+PagingButtonColor=#a0a0b0
+DisabledPagingButtonColor=#e0e0e0
+AuxColor=#6a5acd
+
+# 预编辑：深紫光标
+PreeditColorPreCaret=#6a5acd
+PreeditColorCaret=#9370db
+PreeditColorPostCaret=#333344
+
+# 边框色
+BorderColor=#f0f0f5
+# 分隔线
+DividerColor=#f3f0f7
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+# 深紫夜空
+PanelColor=#201e2b
+HighlightColor=#2d2a3d
+HighlightTextColor=#b39ddb
+TextColor=#e0e0e8
+LabelColor=#6c6a7d
+CommentColor=#6c6a7d
+PagingButtonColor=#b39ddb
+DisabledPagingButtonColor=#3a3847
+AuxColor=#b39ddb
+PreeditColorPreCaret=#b39ddb
+PreeditColorCaret=#9370db
+PreeditColorPostCaret=#e0e0e8
+# 边框色
+BorderColor=#00000000
+# 分隔线
+DividerColor=#2d2a3d
+
+[Typography]
+# 布局
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=Triangle
+
+[Background]
+# 模糊开关
+Blur=True
+# 模糊半径
+BlurRadius=16
+# 阴影
+Shadow=True
+
+[Font]
+# 主文字字号
+TextFontSize=16
+# 标签字号
+LabelFontSize=14
+# 注释字号
+CommentFontSize=12
+# 预编辑字号
+PreeditFontSize=16
+
+[Size]
+# 是否覆盖默认尺寸
+OverrideDefault=True
+# 边框宽度
+BorderWidth=1
+# 圆角
+BorderRadius=12
+# 外边距
+Margin=5
+# 高亮圆角
+HighlightRadius=8
+# 上内边距
+TopPadding=5
+# 右内边距
+RightPadding=10
+# 下内边距
+BottomPadding=5
+# 左内边距
+LeftPadding=10
+# 标签间距
+LabelTextGap=6
+# 垂直最小宽度
+VerticalMinWidth=160
+# 滚动单元宽度
+ScrollCellWidth=65
+# 水平分隔线宽度
+HorizontalDividerWidth=0

--- a/theme/Morandi.conf
+++ b/theme/Morandi.conf
@@ -1,58 +1,87 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 纯白面板
-PanelColor=#ffffff
-# 雾霾紫高亮
+# 高亮颜色
 HighlightColor=#f3f0f7
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#ede8f2
-# 深紫高亮字
+# 高亮文本颜色
 HighlightTextColor=#6a5acd
+# 按下时高亮文本颜色
 HighlightTextPressColor=#483d8b
+# 高亮标签颜色
 HighlightLabelColor=#6a5acd
+# 高亮注释颜色
 HighlightCommentColor=#9370db
+# 高亮标记颜色
 HighlightMarkColor=#6a5acd
-
-# 文字：深岩灰
+# 面板颜色
+PanelColor=#ffffff
+# 文本颜色
 TextColor=#333344
+# 标签颜色
 LabelColor=#a0a0b0
+# 注释颜色
 CommentColor=#b0b0c0
+# 翻页按钮颜色
 PagingButtonColor=#a0a0b0
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#e0e0e0
+# 指示文本颜色
 AuxColor=#6a5acd
-
-# 预编辑：深紫光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#6a5acd
+# 预编辑光标颜色
 PreeditColorCaret=#9370db
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#333344
-
-# 边框色
+# 边框颜色
 BorderColor=#f0f0f5
-# 分隔线
+# 分隔线颜色
 DividerColor=#f3f0f7
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
-# 深紫夜空
-PanelColor=#201e2b
+# 高亮颜色
 HighlightColor=#2d2a3d
+# 悬停时高亮颜色
+HighlightHoverColor=#454545
+# 高亮文本颜色
 HighlightTextColor=#b39ddb
+# 按下时高亮文本颜色
+HighlightTextPressColor=#ff7eb6
+# 高亮标签颜色
+HighlightLabelColor=#ff7eb6
+# 高亮注释颜色
+HighlightCommentColor=#ff7eb6
+# 高亮标记颜色
+HighlightMarkColor=#ff7eb6
+# 面板颜色
+PanelColor=#201e2b
+# 文本颜色
 TextColor=#e0e0e8
+# 标签颜色
 LabelColor=#6c6a7d
+# 注释颜色
 CommentColor=#6c6a7d
+# 翻页按钮颜色
 PagingButtonColor=#b39ddb
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#3a3847
+# 指示文本颜色
 AuxColor=#b39ddb
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#b39ddb
+# 预编辑光标颜色
 PreeditColorCaret=#9370db
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#e0e0e8
-# 边框色
+# 边框颜色
 BorderColor=#00000000
-# 分隔线
+# 分隔线颜色
 DividerColor=#2d2a3d
 
 [Typography]
@@ -60,51 +89,90 @@ DividerColor=#2d2a3d
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=Triangle
 
 [Background]
-# 模糊开关
-Blur=True
-# 模糊半径
-BlurRadius=16
+# 图片
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=System
 # 阴影
 Shadow=True
 
 [Font]
-# 主文字字号
+# 文本字号
 TextFontSize=16
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=14
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=12
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=16
+# 预编辑字重
+PreeditFontWeight=400
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本
+Text=|
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=
+# 悬停行为
+HoverBehavior=Move
 
 [Size]
-# 是否覆盖默认尺寸
+# 覆盖默认值
 OverrideDefault=True
-# 边框宽度
+# 边框宽度（px）
 BorderWidth=1
-# 圆角
+# 边框半径（px）
 BorderRadius=12
-# 外边距
+# 外边距（px）
 Margin=5
-# 高亮圆角
+# 高亮半径（px）
 HighlightRadius=8
-# 上内边距
+# 顶填充（px）
 TopPadding=5
-# 右内边距
+# 右填充（px）
 RightPadding=10
-# 下内边距
+# 底填充（px）
 BottomPadding=5
-# 左内边距
+# 左填充（px）
 LeftPadding=10
-# 标签间距
+# 标签、文本、注释间隔（px）
 LabelTextGap=6
-# 垂直最小宽度
+# 垂直时最小宽度（px）
 VerticalMinWidth=160
-# 滚动单元宽度
+# 卷轴单元格宽度 (px)
 ScrollCellWidth=65
-# 水平分隔线宽度
+# 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/Tiffany.conf
+++ b/theme/Tiffany.conf
@@ -1,59 +1,87 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 纯白礼盒
-PanelColor=#ffffff
-# 水洗 Tiffany 蓝高亮
+# 高亮颜色
 HighlightColor=#e0f7fa
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#d1f2f6
-# 经典蓝文字
+# 高亮文本颜色
 HighlightTextColor=#0abab5
+# 按下时高亮文本颜色
 HighlightTextPressColor=#009688
-# 标签/标记同色
+# 高亮标签颜色
 HighlightLabelColor=#0abab5
+# 高亮注释颜色
 HighlightCommentColor=#4dd0e1
+# 高亮标记颜色
 HighlightMarkColor=#0abab5
-
-# 文字：深灰
+# 面板颜色
+PanelColor=#ffffff
+# 文本颜色
 TextColor=#333333
+# 标签颜色
 LabelColor=#999999
+# 注释颜色
 CommentColor=#b2b2b2
+# 翻页按钮颜色
 PagingButtonColor=#999999
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#e0e0e0
+# 指示文本颜色
 AuxColor=#333333
-
-# 预编辑：Tiffany 蓝光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#0abab5
+# 预编辑光标颜色
 PreeditColorCaret=#0abab5
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#333333
-
-# 边框色
+# 边框颜色
 BorderColor=#e0f2f1
-# 分隔线
+# 分隔线颜色
 DividerColor=#e0f7fa
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
-# 深青灰夜色
-PanelColor=#1d2626
+# 高亮颜色
 HighlightColor=#263238
+# 悬停时高亮颜色
+HighlightHoverColor=#454545
+# 高亮文本颜色
 HighlightTextColor=#4dd0e1
+# 按下时高亮文本颜色
+HighlightTextPressColor=#ff7eb6
+# 高亮标签颜色
+HighlightLabelColor=#ff7eb6
+# 高亮注释颜色
+HighlightCommentColor=#ff7eb6
+# 高亮标记颜色
+HighlightMarkColor=#ff7eb6
+# 面板颜色
+PanelColor=#1d2626
+# 文本颜色
 TextColor=#eceff1
+# 标签颜色
 LabelColor=#607d8b
+# 注释颜色
 CommentColor=#546e7a
+# 翻页按钮颜色
 PagingButtonColor=#4dd0e1
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#37474f
+# 指示文本颜色
 AuxColor=#eceff1
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#4dd0e1
+# 预编辑光标颜色
 PreeditColorCaret=#0abab5
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#eceff1
-# 边框色
+# 边框颜色
 BorderColor=#00000000
-# 分隔线
+# 分隔线颜色
 DividerColor=#263238
 
 [Typography]
@@ -61,51 +89,90 @@ DividerColor=#263238
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=Triangle
 
 [Background]
-# 模糊开关
-Blur=True
-# 模糊半径
-BlurRadius=10
+# 图片
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=System
 # 阴影
 Shadow=True
 
 [Font]
-# 主文字字号
+# 文本字号
 TextFontSize=16
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=14
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=12
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=16
+# 预编辑字重
+PreeditFontWeight=400
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本
+Text=|
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=
+# 悬停行为
+HoverBehavior=Move
 
 [Size]
-# 是否覆盖默认尺寸
-OverrideDefault=True
-# 边框宽度
+# 覆盖默认值
+OverrideDefault=False
+# 边框宽度（px）
 BorderWidth=1
-# 方正微圆角
+# 边框半径（px）
 BorderRadius=6
-# 外边距
+# 外边距（px）
 Margin=6
-# 高亮圆角
+# 高亮半径（px）
 HighlightRadius=4
-# 上内边距
+# 顶填充（px）
 TopPadding=6
-# 右内边距
+# 右填充（px）
 RightPadding=12
-# 下内边距
+# 底填充（px）
 BottomPadding=6
-# 左内边距
+# 左填充（px）
 LeftPadding=12
-# 标签间距
+# 标签、文本、注释间隔（px）
 LabelTextGap=8
-# 垂直最小宽度
+# 垂直时最小宽度（px）
 VerticalMinWidth=160
-# 滚动单元宽度
+# 卷轴单元格宽度 (px)
 ScrollCellWidth=65
-# 水平分隔线宽度
+# 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/Tiffany.conf
+++ b/theme/Tiffany.conf
@@ -1,0 +1,111 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 纯白礼盒
+PanelColor=#ffffff
+# 水洗 Tiffany 蓝高亮
+HighlightColor=#e0f7fa
+# 高亮悬停
+HighlightHoverColor=#d1f2f6
+# 经典蓝文字
+HighlightTextColor=#0abab5
+HighlightTextPressColor=#009688
+# 标签/标记同色
+HighlightLabelColor=#0abab5
+HighlightCommentColor=#4dd0e1
+HighlightMarkColor=#0abab5
+
+# 文字：深灰
+TextColor=#333333
+LabelColor=#999999
+CommentColor=#b2b2b2
+PagingButtonColor=#999999
+DisabledPagingButtonColor=#e0e0e0
+AuxColor=#333333
+
+# 预编辑：Tiffany 蓝光标
+PreeditColorPreCaret=#0abab5
+PreeditColorCaret=#0abab5
+PreeditColorPostCaret=#333333
+
+# 边框色
+BorderColor=#e0f2f1
+# 分隔线
+DividerColor=#e0f7fa
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+# 深青灰夜色
+PanelColor=#1d2626
+HighlightColor=#263238
+HighlightTextColor=#4dd0e1
+TextColor=#eceff1
+LabelColor=#607d8b
+CommentColor=#546e7a
+PagingButtonColor=#4dd0e1
+DisabledPagingButtonColor=#37474f
+AuxColor=#eceff1
+PreeditColorPreCaret=#4dd0e1
+PreeditColorCaret=#0abab5
+PreeditColorPostCaret=#eceff1
+# 边框色
+BorderColor=#00000000
+# 分隔线
+DividerColor=#263238
+
+[Typography]
+# 布局
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=Triangle
+
+[Background]
+# 模糊开关
+Blur=True
+# 模糊半径
+BlurRadius=10
+# 阴影
+Shadow=True
+
+[Font]
+# 主文字字号
+TextFontSize=16
+# 标签字号
+LabelFontSize=14
+# 注释字号
+CommentFontSize=12
+# 预编辑字号
+PreeditFontSize=16
+
+[Size]
+# 是否覆盖默认尺寸
+OverrideDefault=True
+# 边框宽度
+BorderWidth=1
+# 方正微圆角
+BorderRadius=6
+# 外边距
+Margin=6
+# 高亮圆角
+HighlightRadius=4
+# 上内边距
+TopPadding=6
+# 右内边距
+RightPadding=12
+# 下内边距
+BottomPadding=6
+# 左内边距
+LeftPadding=12
+# 标签间距
+LabelTextGap=8
+# 垂直最小宽度
+VerticalMinWidth=160
+# 滚动单元宽度
+ScrollCellWidth=65
+# 水平分隔线宽度
+HorizontalDividerWidth=0

--- a/theme/Twilight.conf
+++ b/theme/Twilight.conf
@@ -1,59 +1,87 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 暖米色底
-PanelColor=#fffbf0
-# 淡杏高亮
+# 高亮颜色
 HighlightColor=#fff0e6
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#ffe0cc
-# 落日橙高亮字
+# 高亮文本颜色
 HighlightTextColor=#ff6b6b
+# 按下时高亮文本颜色
 HighlightTextPressColor=#e65151
-# 标签：暖金
+# 高亮标签颜色
 HighlightLabelColor=#ff9f43
+# 高亮注释颜色
 HighlightCommentColor=#ff9f43
+# 高亮标记颜色
 HighlightMarkColor=#ff6b6b
-
-# 文字：暖棕灰
+# 面板颜色
+PanelColor=#fffbf0
+# 文本颜色
 TextColor=#4a403a
+# 标签颜色
 LabelColor=#a69b95
+# 注释颜色
 CommentColor=#c4b8b0
+# 翻页按钮颜色
 PagingButtonColor=#a69b95
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#ebe0d6
+# 指示文本颜色
 AuxColor=#4a403a
-
-# 预编辑：橙+金光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#ff6b6b
+# 预编辑光标颜色
 PreeditColorCaret=#ff9f43
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#4a403a
-
-# 边框色
+# 边框颜色
 BorderColor=#f5ebe0
-# 分隔线
+# 分隔线颜色
 DividerColor=#fff0e6
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
-# 午夜蓝紫
-PanelColor=#1a1b26
+# 高亮颜色
 HighlightColor=#24283b
+# 悬停时高亮颜色
+HighlightHoverColor=#454545
+# 高亮文本颜色
 HighlightTextColor=#ff9e64
+# 按下时高亮文本颜色
+HighlightTextPressColor=#ff7eb6
+# 高亮标签颜色
+HighlightLabelColor=#ff7eb6
+# 高亮注释颜色
+HighlightCommentColor=#ff7eb6
+# 高亮标记颜色
+HighlightMarkColor=#ff7eb6
+# 面板颜色
+PanelColor=#1a1b26
+# 文本颜色
 TextColor=#c0caf5
+# 标签颜色
 LabelColor=#565f89
+# 注释颜色
 CommentColor=#565f89
+# 翻页按钮颜色
 PagingButtonColor=#ff9e64
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#24283b
+# 指示文本颜色
 AuxColor=#c0caf5
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#ff9e64
+# 预编辑光标颜色
 PreeditColorCaret=#ff9e64
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#c0caf5
-# 边框色
+# 边框颜色
 BorderColor=#00000000
-# 分隔线
+# 分隔线颜色
 DividerColor=#24283b
 
 [Typography]
@@ -61,51 +89,90 @@ DividerColor=#24283b
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=Arrow
 
 [Background]
-# 模糊开关
-Blur=True
-# 模糊半径
-BlurRadius=14
+# 图片
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=Blur
 # 阴影
 Shadow=True
 
 [Font]
-# 主文字字号
+# 文本字号
 TextFontSize=16
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=14
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=12
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=16
+# 预编辑字重
+PreeditFontWeight=400
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本
+Text=‸
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=
+# 悬停行为
+HoverBehavior=Move
 
 [Size]
-# 是否覆盖默认尺寸
+# 覆盖默认值
 OverrideDefault=True
-# 边框宽度
+# 边框宽度（px）
 BorderWidth=1
-# 圆角
+# 边框半径（px）
 BorderRadius=12
-# 外边距
+# 外边距（px）
 Margin=6
-# 高亮圆角
+# 高亮半径（px）
 HighlightRadius=8
-# 上内边距
+# 顶填充（px）
 TopPadding=6
-# 右内边距
+# 右填充（px）
 RightPadding=10
-# 下内边距
+# 底填充（px）
 BottomPadding=6
-# 左内边距
+# 左填充（px）
 LeftPadding=10
-# 标签间距
+# 标签、文本、注释间隔（px）
 LabelTextGap=8
-# 垂直最小宽度
+# 垂直时最小宽度（px）
 VerticalMinWidth=160
-# 滚动单元宽度
+# 卷轴单元格宽度 (px)
 ScrollCellWidth=65
-# 水平分隔线宽度
+# 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/Twilight.conf
+++ b/theme/Twilight.conf
@@ -1,0 +1,111 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 暖米色底
+PanelColor=#fffbf0
+# 淡杏高亮
+HighlightColor=#fff0e6
+# 高亮悬停
+HighlightHoverColor=#ffe0cc
+# 落日橙高亮字
+HighlightTextColor=#ff6b6b
+HighlightTextPressColor=#e65151
+# 标签：暖金
+HighlightLabelColor=#ff9f43
+HighlightCommentColor=#ff9f43
+HighlightMarkColor=#ff6b6b
+
+# 文字：暖棕灰
+TextColor=#4a403a
+LabelColor=#a69b95
+CommentColor=#c4b8b0
+PagingButtonColor=#a69b95
+DisabledPagingButtonColor=#ebe0d6
+AuxColor=#4a403a
+
+# 预编辑：橙+金光标
+PreeditColorPreCaret=#ff6b6b
+PreeditColorCaret=#ff9f43
+PreeditColorPostCaret=#4a403a
+
+# 边框色
+BorderColor=#f5ebe0
+# 分隔线
+DividerColor=#fff0e6
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+# 午夜蓝紫
+PanelColor=#1a1b26
+HighlightColor=#24283b
+HighlightTextColor=#ff9e64
+TextColor=#c0caf5
+LabelColor=#565f89
+CommentColor=#565f89
+PagingButtonColor=#ff9e64
+DisabledPagingButtonColor=#24283b
+AuxColor=#c0caf5
+PreeditColorPreCaret=#ff9e64
+PreeditColorCaret=#ff9e64
+PreeditColorPostCaret=#c0caf5
+# 边框色
+BorderColor=#00000000
+# 分隔线
+DividerColor=#24283b
+
+[Typography]
+# 布局
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=Arrow
+
+[Background]
+# 模糊开关
+Blur=True
+# 模糊半径
+BlurRadius=14
+# 阴影
+Shadow=True
+
+[Font]
+# 主文字字号
+TextFontSize=16
+# 标签字号
+LabelFontSize=14
+# 注释字号
+CommentFontSize=12
+# 预编辑字号
+PreeditFontSize=16
+
+[Size]
+# 是否覆盖默认尺寸
+OverrideDefault=True
+# 边框宽度
+BorderWidth=1
+# 圆角
+BorderRadius=12
+# 外边距
+Margin=6
+# 高亮圆角
+HighlightRadius=8
+# 上内边距
+TopPadding=6
+# 右内边距
+RightPadding=10
+# 下内边距
+BottomPadding=6
+# 左内边距
+LeftPadding=10
+# 标签间距
+LabelTextGap=8
+# 垂直最小宽度
+VerticalMinWidth=160
+# 滚动单元宽度
+ScrollCellWidth=65
+# 水平分隔线宽度
+HorizontalDividerWidth=0

--- a/theme/blibli.conf
+++ b/theme/blibli.conf
@@ -1,0 +1,151 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 白卡样式高亮
+HighlightColor=#ffffff
+# 高亮悬停
+HighlightHoverColor=#ffffff
+# 粉红高亮字
+HighlightTextColor=#e6195e
+HighlightTextPressColor=#c41550
+# 序号/标记同色
+HighlightLabelColor=#e6195e
+HighlightCommentColor=#e6195e
+HighlightMarkColor=#e6195e
+
+# 奶油白面板，深灰文字
+PanelColor=#fcfbf3
+TextColor=#3d3733
+LabelColor=#888888
+CommentColor=#aaaaaa
+PagingButtonColor=#888888
+DisabledPagingButtonColor=#d0d0d0
+AuxColor=#3d3733
+
+# 预编辑：黑码 + 粉光标
+PreeditColorPreCaret=#000000
+PreeditColorCaret=#e6195e
+PreeditColorPostCaret=#000000
+
+# 边框色
+BorderColor=#e2e2e2
+# 分隔线
+DividerColor=#ececec
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+HighlightColor=#3f3f3f
+# 高亮悬停
+HighlightHoverColor=#454545
+# 粉色高亮字
+HighlightTextColor=#ff7eb6
+HighlightTextPressColor=#ff7eb6
+HighlightLabelColor=#ff7eb6
+HighlightCommentColor=#ff7eb6
+HighlightMarkColor=#ff7eb6
+
+# 深灰面板，白字
+PanelColor=#2b2b2b
+TextColor=#ffffff
+LabelColor=#aaaaaa
+CommentColor=#aaaaaa
+PagingButtonColor=#ffffff
+DisabledPagingButtonColor=#606060
+AuxColor=#ffffff
+
+# 预编辑：粉光标
+PreeditColorPreCaret=#ff7eb6
+PreeditColorCaret=#ff7eb6
+PreeditColorPostCaret=#ffffff
+
+# 边框色
+BorderColor=#1a1a1a
+# 分隔线
+DividerColor=#343434
+
+[Typography]
+# 布局
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=Triangle
+
+[Background]
+# 图片 (留空以使用纯色绘制)
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=True
+# 模糊半径（px）
+BlurRadius=10
+# 阴影
+Shadow=True
+
+[Font]
+# 文本字号 (根据图片调整为较大字号)
+TextFontSize=18
+# 标签字号
+LabelFontSize=18
+# 注释字号
+CommentFontSize=14
+# 预编辑字号
+PreeditFontSize=18
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本 (光标字符)
+Text=|
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=
+# 悬停行为
+HoverBehavior=Move
+
+[Size]
+# 覆盖默认值
+OverrideDefault=True
+# 边框宽度（px）
+BorderWidth=1
+# 边框半径（px）(主窗口圆角)
+BorderRadius=10
+# 外边距（px）
+Margin=6
+# 高亮半径（px）(高亮卡片圆角)
+HighlightRadius=6
+# 顶填充（px）
+TopPadding=6
+# 右填充（px）
+RightPadding=10
+# 底填充（px）
+BottomPadding=6
+# 左填充（px）
+LeftPadding=10
+# 标签、文本、注释间隔（px）
+LabelTextGap=6
+# 垂直时最小宽度（px）
+VerticalMinWidth=160
+# 卷轴单元格宽度 (px)
+ScrollCellWidth=65
+# 水平分隔线宽度（px）
+HorizontalDividerWidth=0

--- a/theme/blibli.conf
+++ b/theme/blibli.conf
@@ -1,69 +1,87 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 白卡样式高亮
+# 高亮颜色
 HighlightColor=#ffffff
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#ffffff
-# 粉红高亮字
+# 高亮文本颜色
 HighlightTextColor=#e6195e
+# 按下时高亮文本颜色
 HighlightTextPressColor=#c41550
-# 序号/标记同色
+# 高亮标签颜色
 HighlightLabelColor=#e6195e
+# 高亮注释颜色
 HighlightCommentColor=#e6195e
+# 高亮标记颜色
 HighlightMarkColor=#e6195e
-
-# 奶油白面板，深灰文字
+# 面板颜色
 PanelColor=#fcfbf3
+# 文本颜色
 TextColor=#3d3733
+# 标签颜色
 LabelColor=#888888
+# 注释颜色
 CommentColor=#aaaaaa
+# 翻页按钮颜色
 PagingButtonColor=#888888
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#d0d0d0
+# 指示文本颜色
 AuxColor=#3d3733
-
-# 预编辑：黑码 + 粉光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#000000
+# 预编辑光标颜色
 PreeditColorCaret=#e6195e
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#000000
-
-# 边框色
+# 边框颜色
 BorderColor=#e2e2e2
-# 分隔线
+# 分隔线颜色
 DividerColor=#ececec
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
+# 高亮颜色
 HighlightColor=#3f3f3f
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#454545
-# 粉色高亮字
+# 高亮文本颜色
 HighlightTextColor=#ff7eb6
+# 按下时高亮文本颜色
 HighlightTextPressColor=#ff7eb6
+# 高亮标签颜色
 HighlightLabelColor=#ff7eb6
+# 高亮注释颜色
 HighlightCommentColor=#ff7eb6
+# 高亮标记颜色
 HighlightMarkColor=#ff7eb6
-
-# 深灰面板，白字
+# 面板颜色
 PanelColor=#2b2b2b
+# 文本颜色
 TextColor=#ffffff
+# 标签颜色
 LabelColor=#aaaaaa
+# 注释颜色
 CommentColor=#aaaaaa
+# 翻页按钮颜色
 PagingButtonColor=#ffffff
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#606060
+# 指示文本颜色
 AuxColor=#ffffff
-
-# 预编辑：粉光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#ff7eb6
+# 预编辑光标颜色
 PreeditColorCaret=#ff7eb6
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#ffffff
-
-# 边框色
+# 边框颜色
 BorderColor=#1a1a1a
-# 分隔线
+# 分隔线颜色
 DividerColor=#343434
 
 [Typography]
@@ -71,30 +89,38 @@ DividerColor=#343434
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=Triangle
 
 [Background]
-# 图片 (留空以使用纯色绘制)
+# 图片
 ImageUrl=
 # 有图片时保留面板颜色
 KeepPanelColorWhenHasImage=False
 # 模糊
-Blur=True
-# 模糊半径（px）
-BlurRadius=10
+Blur=System
 # 阴影
 Shadow=True
 
 [Font]
-# 文本字号 (根据图片调整为较大字号)
+# 文本字号
 TextFontSize=18
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=18
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=14
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=18
+# 预编辑字重
+PreeditFontWeight=400
 
 [Font/TextFontFamily]
 0=
@@ -111,7 +137,7 @@ PreeditFontSize=18
 [Caret]
 # 样式
 Style=Blink
-# 文本 (光标字符)
+# 文本
 Text=|
 
 [Highlight]
@@ -127,11 +153,11 @@ HoverBehavior=Move
 OverrideDefault=True
 # 边框宽度（px）
 BorderWidth=1
-# 边框半径（px）(主窗口圆角)
+# 边框半径（px）
 BorderRadius=10
 # 外边距（px）
 Margin=6
-# 高亮半径（px）(高亮卡片圆角)
+# 高亮半径（px）
 HighlightRadius=6
 # 顶填充（px）
 TopPadding=6
@@ -149,3 +175,4 @@ VerticalMinWidth=160
 ScrollCellWidth=65
 # 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/nordic.conf
+++ b/theme/nordic.conf
@@ -1,55 +1,87 @@
 [LightMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 冰蓝高亮
+# 高亮颜色
 HighlightColor=#eceff4
-# 高亮悬停
+# 悬停时高亮颜色
 HighlightHoverColor=#e5e9f0
-# Nord 蓝文字
+# 高亮文本颜色
 HighlightTextColor=#5e81ac
+# 按下时高亮文本颜色
 HighlightTextPressColor=#5e81ac
+# 高亮标签颜色
 HighlightLabelColor=#5e81ac
+# 高亮注释颜色
 HighlightCommentColor=#81a1c1
+# 高亮标记颜色
 HighlightMarkColor=#88c0d0
-# 纯白面板
+# 面板颜色
 PanelColor=#ffffff
-# 深蓝文字
+# 文本颜色
 TextColor=#2e3440
+# 标签颜色
 LabelColor=#4c566a
+# 注释颜色
 CommentColor=#d8dee9
+# 翻页按钮颜色
 PagingButtonColor=#4c566a
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#d8dee9
+# 指示文本颜色
 AuxColor=#2e3440
-# 预编辑：蓝光标
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#5e81ac
+# 预编辑光标颜色
 PreeditColorCaret=#bf616a
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#2e3440
-# 边框色
+# 边框颜色
 BorderColor=#d8dee9
-# 分隔线
+# 分隔线颜色
 DividerColor=#eceff4
 
 [DarkMode]
-# 是否覆盖默认
+# 覆盖默认值
 OverrideDefault=True
-# 与浅色是否同色
+# 与浅色模式相同
 SameWithLightMode=False
-# 深蓝灰底
-PanelColor=#2e3440
+# 高亮颜色
 HighlightColor=#3b4252
+# 悬停时高亮颜色
+HighlightHoverColor=#454545
+# 高亮文本颜色
 HighlightTextColor=#88c0d0
+# 按下时高亮文本颜色
+HighlightTextPressColor=#ff7eb6
+# 高亮标签颜色
+HighlightLabelColor=#ff7eb6
+# 高亮注释颜色
+HighlightCommentColor=#ff7eb6
+# 高亮标记颜色
+HighlightMarkColor=#ff7eb6
+# 面板颜色
+PanelColor=#2e3440
+# 文本颜色
 TextColor=#eceff4
+# 标签颜色
 LabelColor=#d8dee9
+# 注释颜色
 CommentColor=#4c566a
+# 翻页按钮颜色
 PagingButtonColor=#eceff4
+# 禁用的翻页按钮颜色
 DisabledPagingButtonColor=#4c566a
+# 指示文本颜色
 AuxColor=#eceff4
+# 光标前的预编辑颜色
 PreeditColorPreCaret=#88c0d0
+# 预编辑光标颜色
 PreeditColorCaret=#bf616a
+# 光标后的预编辑颜色
 PreeditColorPostCaret=#eceff4
-# 边框色
+# 边框颜色
 BorderColor=#00000000
-# 分隔线
+# 分隔线颜色
 DividerColor=#3b4252
 
 [Typography]
@@ -57,51 +89,90 @@ DividerColor=#3b4252
 Layout=Horizontal
 # 书写模式
 WritingMode="Horizontal top-bottom"
+# 垂直时注释右对齐
+VerticalCommentsAlignRight=False
 # 翻页按钮样式
 PagingButtonsStyle=Arrow
 
 [Background]
-# 模糊开关
-Blur=True
-# 模糊半径
-BlurRadius=10
+# 图片
+ImageUrl=
+# 有图片时保留面板颜色
+KeepPanelColorWhenHasImage=False
+# 模糊
+Blur=System
 # 阴影
 Shadow=True
 
 [Font]
-# 主文字字号
+# 文本字号
 TextFontSize=16
+# 文本字重
+TextFontWeight=400
 # 标签字号
 LabelFontSize=14
+# 标签字重
+LabelFontWeight=400
 # 注释字号
 CommentFontSize=12
+# 注释字重
+CommentFontWeight=400
 # 预编辑字号
 PreeditFontSize=16
+# 预编辑字重
+PreeditFontWeight=400
+
+[Font/TextFontFamily]
+0=
+
+[Font/LabelFontFamily]
+0=
+
+[Font/CommentFontFamily]
+0=
+
+[Font/PreeditFontFamily]
+0=
+
+[Caret]
+# 样式
+Style=Blink
+# 文本
+Text=|
+
+[Highlight]
+# 标记样式
+MarkStyle=None
+# 标记文本
+MarkText=
+# 悬停行为
+HoverBehavior=Move
 
 [Size]
-# 是否覆盖默认尺寸
+# 覆盖默认值
 OverrideDefault=True
-# 边框宽度
+# 边框宽度（px）
 BorderWidth=1
-# 圆角
+# 边框半径（px）
 BorderRadius=10
-# 外边距
+# 外边距（px）
 Margin=6
-# 高亮圆角
+# 高亮半径（px）
 HighlightRadius=6
-# 上内边距
+# 顶填充（px）
 TopPadding=6
-# 右内边距
+# 右填充（px）
 RightPadding=10
-# 下内边距
+# 底填充（px）
 BottomPadding=6
-# 左内边距
+# 左填充（px）
 LeftPadding=10
-# 标签间距
+# 标签、文本、注释间隔（px）
 LabelTextGap=6
-# 垂直最小宽度
+# 垂直时最小宽度（px）
 VerticalMinWidth=160
-# 滚动单元宽度
+# 卷轴单元格宽度 (px)
 ScrollCellWidth=65
-# 水平分隔线宽度
+# 水平分隔线宽度（px）
 HorizontalDividerWidth=0
+

--- a/theme/nordic.conf
+++ b/theme/nordic.conf
@@ -1,0 +1,107 @@
+[LightMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 冰蓝高亮
+HighlightColor=#eceff4
+# 高亮悬停
+HighlightHoverColor=#e5e9f0
+# Nord 蓝文字
+HighlightTextColor=#5e81ac
+HighlightTextPressColor=#5e81ac
+HighlightLabelColor=#5e81ac
+HighlightCommentColor=#81a1c1
+HighlightMarkColor=#88c0d0
+# 纯白面板
+PanelColor=#ffffff
+# 深蓝文字
+TextColor=#2e3440
+LabelColor=#4c566a
+CommentColor=#d8dee9
+PagingButtonColor=#4c566a
+DisabledPagingButtonColor=#d8dee9
+AuxColor=#2e3440
+# 预编辑：蓝光标
+PreeditColorPreCaret=#5e81ac
+PreeditColorCaret=#bf616a
+PreeditColorPostCaret=#2e3440
+# 边框色
+BorderColor=#d8dee9
+# 分隔线
+DividerColor=#eceff4
+
+[DarkMode]
+# 是否覆盖默认
+OverrideDefault=True
+# 与浅色是否同色
+SameWithLightMode=False
+# 深蓝灰底
+PanelColor=#2e3440
+HighlightColor=#3b4252
+HighlightTextColor=#88c0d0
+TextColor=#eceff4
+LabelColor=#d8dee9
+CommentColor=#4c566a
+PagingButtonColor=#eceff4
+DisabledPagingButtonColor=#4c566a
+AuxColor=#eceff4
+PreeditColorPreCaret=#88c0d0
+PreeditColorCaret=#bf616a
+PreeditColorPostCaret=#eceff4
+# 边框色
+BorderColor=#00000000
+# 分隔线
+DividerColor=#3b4252
+
+[Typography]
+# 布局
+Layout=Horizontal
+# 书写模式
+WritingMode="Horizontal top-bottom"
+# 翻页按钮样式
+PagingButtonsStyle=Arrow
+
+[Background]
+# 模糊开关
+Blur=True
+# 模糊半径
+BlurRadius=10
+# 阴影
+Shadow=True
+
+[Font]
+# 主文字字号
+TextFontSize=16
+# 标签字号
+LabelFontSize=14
+# 注释字号
+CommentFontSize=12
+# 预编辑字号
+PreeditFontSize=16
+
+[Size]
+# 是否覆盖默认尺寸
+OverrideDefault=True
+# 边框宽度
+BorderWidth=1
+# 圆角
+BorderRadius=10
+# 外边距
+Margin=6
+# 高亮圆角
+HighlightRadius=6
+# 上内边距
+TopPadding=6
+# 右内边距
+RightPadding=10
+# 下内边距
+BottomPadding=6
+# 左内边距
+LeftPadding=10
+# 标签间距
+LabelTextGap=6
+# 垂直最小宽度
+VerticalMinWidth=160
+# 滚动单元宽度
+ScrollCellWidth=65
+# 水平分隔线宽度
+HorizontalDividerWidth=0


### PR DESCRIPTION
## 变更
- 新增主题：BlackGold、Morandi、Ink、Matcha、Tiffany、Twilight、blibli、nordic。
- 每个主题按现有示例风格提供简洁中文注释，便于二次调整配色与参数。

## 说明
- 仅添加新文件，未改动现有主题或默认配置。
- 配色与尺寸参数与本地测试一致，可直接使用。